### PR TITLE
This fixes an issue with a custom title-view (which has a title and a…

### DIFF
--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -381,13 +381,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
   NSMutableDictionary *titleTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarText" baseFont:[UIFont boldSystemFontOfSize:17]];
   [self.navigationController.navigationBar setTitleTextAttributes:titleTextAttributes];
   
-  if (self.navigationItem.titleView && [self.navigationItem.titleView isKindOfClass:[RCCTitleView class]]) {
-    
-    RCCTitleView *titleView = (RCCTitleView *)self.navigationItem.titleView;
-    RCCTitleViewHelper *helper = [[RCCTitleViewHelper alloc] init:viewController navigationController:viewController.navigationController title:titleView.titleLabel.text subtitle:titleView.subtitleLabel.text titleImageData:nil isSetSubtitle:NO];
-    [helper setup:self.navigatorStyle];
-  }
-  
   NSMutableDictionary *navButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarButton"];
   NSMutableDictionary *leftNavButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarLeftButton"];
   NSMutableDictionary *rightNavButtonTextAttributes = [RCTHelpers textAttributesFromDictionary:self.navigatorStyle withPrefix:@"navBarRightButton"];


### PR DESCRIPTION
… subtitle) appearing at the left side of the nav-bar instead of the center during a transition animation: when a screen with this title-view is being pushed or when you pop back to it. (#2384)

This happens because the title-view is being created again when RVVViewController appears. There's probably no point in setting the title-view again with the same data when it already has it. The title view setup is done anyway in RCCNavigationController.

This can be easily reproduced by calling "this.props.navigator.setSubTitle({subtitle: 'a subtitle'});" from the constructor of a pushed screen.